### PR TITLE
re-enable project simulation

### DIFF
--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -269,8 +269,8 @@ class Node(object):
             simulated_data[list]: list of simulated record
         """
         # skip project node
-        if not self.required_links:
-            return
+        # if not self.required_links:
+        #     return
 
         # re compute n-samples base on link type (one_to_one, one_to_many, ..etc.)
         min_required_samples = sys.maxint

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -307,6 +307,9 @@ class Node(object):
                 example["submitter_id"] = self._simulate_submitter_id()
             example["type"] = self.name
 
+            if self.name == 'project':
+                example["code"] = self.project
+
             simulated_data.append(example)
 
         # simulate link properties

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -316,7 +316,10 @@ class Node(object):
         try:
             self._simulate_link_properties(simulated_data, random)
             # store to dataset
-            self.simulated_dataset = simulated_data
+            if self.name == 'project':
+                self.simulated_dataset = simulated_data[0]
+            else:
+                self.simulated_dataset = simulated_data
         except IndexError:
             # just skip it
             pass

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -303,7 +303,8 @@ class Node(object):
                         simple_schema
                     )
 
-            example["submitter_id"] = self._simulate_submitter_id()
+            if self.name != 'project':
+                example["submitter_id"] = self._simulate_submitter_id()
             example["type"] = self.name
 
             simulated_data.append(example)


### PR DESCRIPTION
I think this is terrible and hacky and I would like to fix it after the workshop... but.

Note: Reason for this 
```
            if self.name == 'project':
                self.simulated_dataset = simulated_data[0]
            else:
                self.simulated_dataset = simulated_data
```
is this sheepdog error: `"Program endpoint only supports single documents"`