### PR TITLE
Feat/no consent codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Optional arguments:
 * required_only: only simulate required properties
 * random: randomly generate the numbers of node instances. If this argument is not used, all nodes have `max_samples` instances
 * node_num_instances_file ./file.json: generate the numbers of node instances specified in the JSON file. The file should contain the number of instances (integer)  to generate for each node name, for example: `{"submitted_unaligned_reads": 100}`. `max_samples` instances are generated for nodes that are not specified in the file.
+* consent_codes: whether to include generation of random consent codes
 
 #### Submission Order
 

--- a/bin/data-simulator
+++ b/bin/data-simulator
@@ -52,6 +52,10 @@ def parse_arguments():
     )
 
     simulate_data_cmd.add_argument(
+        "--consent_codes", help="include generation of random consent codes", action="store_true"
+    )
+
+    simulate_data_cmd.add_argument(
         "--skip", help="skip raising an exception if gets an error", action="store_true"
     )
 
@@ -83,7 +87,7 @@ def main():
     if args.action == "simulate":
         # Initialize graph
         graph = Graph(dictionary, program=args.program, project=args.project)
-        graph.generate_nodes_from_dictionary()
+        graph.generate_nodes_from_dictionary(args.consent_codes)
         graph.construct_graph_edges()
         max_samples = int(args.max_samples)
 

--- a/datasimulator/generator.py
+++ b/datasimulator/generator.py
@@ -22,7 +22,6 @@ def generate_string_data(size=10, pattern=None):
         return "{}_{}".format(random.choice(WORDS), random.choice(WORDS))
 
 
-
 def generate_number(minx=0, maxx=100, is_int=False):
     return random.randint(minx, maxx) if is_int else random.uniform(minx, maxx)
 
@@ -86,3 +85,8 @@ def generate_simple_primitive_data(data_type, pattern=None, maxx=100, minx=0):
         return generate_boolean()
 
     raise UserError("{} is not supported".format(data_type))
+
+
+def generate_consent_code(size=5):
+    pattern = "^[A-Z]{" + str(size) + "}"
+    return rstr.xeger(pattern)

--- a/datasimulator/graph.py
+++ b/datasimulator/graph.py
@@ -46,14 +46,16 @@ class Graph(object):
         """
         return [k for k in self.dictionary.schema if k not in EXCLUDED_NODE]
 
-    def generate_nodes_from_dictionary(self):
+    def generate_nodes_from_dictionary(self, consent_codes=False):
         """
         generate nodes from dictionary
 
+        Args:
+            consent_codes(bool): whether to include generation of random consent codes
         """
         # logger.info('Start simulating data')
         for node_name in self._get_list_of_node_names():
-            node = Node(node_name, self.dictionary.schema[node_name], self.project)
+            node = Node(node_name, self.dictionary.schema[node_name], self.project, consent_codes)
             if node_name == "project":
                 self.root = node
             self.nodes.append(node)

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -37,11 +37,12 @@ class Node(object):
     Class representation for node
     """
 
-    def __init__(self, node_name, node_schema, project):
+    def __init__(self, node_name, node_schema, project, consent_codes):
         """
         """
         self.name = node_name
         self.project = project
+        self.consent_codes = consent_codes
         self.required = node_schema.get("required", [])
         self.sys_properties = node_schema.get("systemProperties", [])
         try:
@@ -174,6 +175,10 @@ class Node(object):
                 or prop in EXCLUDED_FIELDS
                 or (required_only and prop not in self.required)
             ):
+                continue
+
+            # ignore consent_codes unless specified otherwise
+            if not self.consent_codes and prop == "consent_codes":
                 continue
 
             template[prop] = self.construct_simple_property_schema(

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -9,6 +9,7 @@ from .generator import (
     generate_datetime,
     generate_string_data,
     generate_array_data_type,
+    generate_consent_code,
     generate_simple_primitive_data,
 )
 from .utils import is_mixed_type, random_choice, get_keys_list
@@ -92,6 +93,10 @@ class Node(object):
                 maxx=simple_schema.get("max"),
                 minx=simple_schema.get("min"),
             )
+
+    @staticmethod
+    def _simulate_consent_code():
+        return ["/consent/{}".format(generate_consent_code())]
 
     def node_validation(self, required_only=False):
         """
@@ -311,6 +316,8 @@ class Node(object):
                 # Skip. Simulate link properties later
                 elif simple_schema["data_type"] == "link_type":
                     continue
+                elif prop == "consent_codes":
+                    example[prop] = Node._simulate_consent_code()
                 else:
                     example[prop] = Node._simulate_data_from_simple_schema(
                         simple_schema

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -182,10 +182,6 @@ class Node(object):
             ):
                 continue
 
-            # ignore consent_codes unless specified otherwise
-            if not self.consent_codes and prop == "consent_codes":
-                continue
-
             template[prop] = self.construct_simple_property_schema(
                 prop=prop, prop_schema=prop_schema
             )
@@ -317,7 +313,7 @@ class Node(object):
                 elif simple_schema["data_type"] == "link_type":
                     continue
                 elif prop == "consent_codes":
-                    example[prop] = Node._simulate_consent_code()
+                    example[prop] = Node._simulate_consent_code() if self.consent_codes else []
                 else:
                     example[prop] = Node._simulate_data_from_simple_schema(
                         simple_schema


### PR DESCRIPTION
adds a `--consent-codes` param to the `simulate` command