### PR TITLE
Update Dockerfile to use python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y sudo python-pip git python-dev libpq-dev apache2 libapache2-mod-wsgi vim libssl-dev libffi-dev wamerican \ 
+RUN apt-get update && apt-get install -y sudo python3-pip git python3-dev libpq-dev apache2 libapache2-mod-wsgi vim libssl-dev libffi-dev wamerican \ 
  && apt-get clean && apt-get autoremove \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && pip3 install --upgrade pip
 
 COPY . /data-simulator
 WORKDIR /data-simulator
 
 RUN  pip install -r requirements.txt \
-     && python setup.py develop
+     && /usr/bin/python3 setup.py develop


### PR DESCRIPTION
### Deployment changes
- Dockerfile uses python3 to install data-simulator

