### PR TITLE
PXP-9192 Handle generating strings in date-time format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,6 @@ repos:
     -   id: no-commit-to-branch
         args: [--branch, develop, --branch, master, --pattern, release/.*]
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Required arguments:
 Optional arguments:
 * max_samples: maximum number of instances for each node. default is 1
 * required_only: only simulate required properties
-* random: randomly generate the numbers of node instances. If this argument is not used, all nodes have `max_samples` instances
+* random: randomly generate the numbers of node instances (up to `max_samples`). If this argument is not used, all nodes have `max_samples` instances
 * node_num_instances_file ./file.json: generate the numbers of node instances specified in the JSON file. The file should contain the number of instances (integer)  to generate for each node name, for example: `{"submitted_unaligned_reads": 100}`. `max_samples` instances are generated for nodes that are not specified in the file.
 * consent_codes: whether to include generation of random consent codes
 
@@ -68,7 +68,7 @@ data-simulator submitting_data --host http://devplanet.planx-pla.net --project D
 Required arguments:
 * dir: path containing data
 * host
-* project
+* project: program name and project code separated by a forward slash
 * access_token_file
 
 Optional arguments:

--- a/datasimulator/generator.py
+++ b/datasimulator/generator.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import rstr
 import random
 
@@ -7,7 +8,10 @@ tried_words = False
 WORDS = None
 
 
-def generate_string_data(size=10, pattern=None):
+def generate_string_data(size=10, pattern=None, format=None):
+    if format:
+        return generate_string_data_with_format(format)
+
     global tried_words, WORDS
     if not tried_words:
         tried_words = True
@@ -21,6 +25,21 @@ def generate_string_data(size=10, pattern=None):
         return rstr.xeger(pattern)
     else:
         return "{}_{}".format(random.choice(WORDS), random.choice(WORDS))
+
+
+def generate_string_data_with_format(format):
+    if format == "date-time":
+        min_year = 1980
+        max_year = 2020
+        start = datetime(min_year, 1, 1, 00, 00, 00)
+        years = max_year - min_year + 1
+        end = start + timedelta(days=365 * years)
+        random_datetime = start + (end - start) * random.random()
+        return random_datetime.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    else:
+        raise UserError(
+            f"Format '{format}' is not currently supported by data-simulator"
+        )
 
 
 def generate_number(minx=0, maxx=100, is_int=False):
@@ -51,10 +70,13 @@ def generate_datetime():
 
 
 def generate_array_data_type(
-    item_type, n_items=1, item_predefined_values=[], pattern=None
+    item_type, n_items=1, item_predefined_values=[], pattern=None, format=None
 ):
     if item_type == "string":
-        return [generate_string_data(size=10, pattern=pattern) for _ in range(n_items)]
+        return [
+            generate_string_data(size=10, pattern=pattern, format=format)
+            for _ in range(n_items)
+        ]
     elif item_type == "integer":
         return [generate_number(is_int=True) for _ in range(n_items)]
     elif item_type in {"float", "number"}:
@@ -65,12 +87,14 @@ def generate_array_data_type(
         raise UserError("{} is not supported".format(item_type))
 
 
-def generate_simple_primitive_data(data_type, pattern=None, maxx=None, minx=None):
+def generate_simple_primitive_data(
+    data_type, pattern=None, maxx=None, minx=None, format=None
+):
     """
     Generate a single primitive data
     """
     if data_type == "string":
-        return generate_string_data(pattern=pattern)
+        return generate_string_data(pattern=pattern, format=format)
 
     if data_type == "boolean":
         return generate_boolean()

--- a/datasimulator/new/node_simulator.py
+++ b/datasimulator/new/node_simulator.py
@@ -106,25 +106,3 @@ def construct_simple_property_schema(node_name, prop, prop_schema):
             ),
             "error_type": "DictionaryError",
         }
-
-
-def _simulate_data_from_simple_schema(simple_schema):
-    if simple_schema["data_type"] == "md5sum":
-        return generate_hash()
-    elif simple_schema["data_type"] == "enum":
-        return random_choice(simple_schema["values"])
-    elif simple_schema["data_type"] == "datetime":
-        return generate_datetime()
-    elif simple_schema["data_type"] == "array":
-        return generate_array_data_type(
-            item_type=simple_schema.get("item_type"),
-            n_items=1,
-            item_predefined_values=simple_schema.get("item_enum_data", []),
-        )
-    else:
-        return generate_simple_primitive_data(
-            data_type=simple_schema["data_type"],
-            pattern=simple_schema.get("pattern"),
-            maxx=simple_schema.get("max"),
-            minx=simple_schema.get("min"),
-        )

--- a/datasimulator/new/simulator.py
+++ b/datasimulator/new/simulator.py
@@ -71,25 +71,29 @@ def simulate_relations(model, dictionary, graph_node, project_name):
 
 def simulate_node_project(props, properties, data_node, project_name):
     data_node["type"] = "project"
-    for k, v in props.items():
-        prop_schema = construct_simple_property_schema("project", k, properties[k])
+    for prop in props.keys():
+        prop_schema = construct_simple_property_schema(
+            "project", prop, properties[prop]
+        )
         if prop_schema is None:
             continue
         if prop_schema["data_type"] is None:
             logger.warning(prop_schema["error_msg"])
         # Skip. Simulate link properties later
-        elif k == "name":
-            data_node[k] = project_name
-        elif k == "code":
+        elif prop == "name":
+            data_node[prop] = project_name
+        elif prop == "code":
             continue
         else:
-            data_node[k] = _simulate_data_from_simple_schema(prop_schema)
+            data_node[prop] = _simulate_data_from_simple_schema(prop_schema)
 
 
 def simulate_node_properties(props, properties, node_name, data_node):
     data_node["type"] = node_name
-    for k, v in props.items():
-        prop_schema = construct_simple_property_schema(node_name, k, properties[k])
+    for prop in props.keys():
+        prop_schema = construct_simple_property_schema(
+            node_name, prop, properties[prop]
+        )
         if prop_schema is None:
             continue
         if prop_schema["data_type"] is None:
@@ -98,7 +102,7 @@ def simulate_node_properties(props, properties, node_name, data_node):
         elif prop_schema["data_type"] == "link_type":
             continue
         else:
-            data_node[k] = _simulate_data_from_simple_schema(prop_schema)
+            data_node[prop] = _simulate_data_from_simple_schema(prop_schema)
 
 
 def simulate_nodes_properties(model, dictionary, graph_node, project_name):
@@ -110,7 +114,7 @@ def simulate_nodes_properties(model, dictionary, graph_node, project_name):
     }
     properties = dictionary.schema[graph_node.name]["properties"]
 
-    for k, v in nodes_by_node_name[graph_node.name].items():
+    for v in nodes_by_node_name[graph_node.name].values():
         if len(nodes_by_node_name[graph_node.name]) == 0:
             continue
         if graph_node.name == "project":

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -88,6 +88,7 @@ class Node(object):
                 n_items=1,
                 item_predefined_values=simple_schema.get("item_enum_data", []),
                 pattern=simple_schema.get("pattern", None),
+                format=simple_schema.get("format"),
             )
         else:
             return generate_simple_primitive_data(
@@ -95,6 +96,7 @@ class Node(object):
                 pattern=simple_schema.get("pattern"),
                 maxx=simple_schema.get("max"),
                 minx=simple_schema.get("min"),
+                format=simple_schema.get("format"),
             )
 
     @staticmethod
@@ -208,8 +210,7 @@ class Node(object):
 
         prop_type = prop_schema.get("type")
         if prop_type:
-
-            # if type if a list, use the first allowed type
+            # if type is a list, use the first allowed type
             if isinstance(prop_type, list):
                 if "null" in prop_type:
                     prop_type.remove("null")
@@ -242,17 +243,26 @@ class Node(object):
                         ),
                         "error_type": "DictionaryError",
                     }
-                return {
+
+                simple_schema = {
                     "data_type": prop_type,
                     "item_type": prop_schema.get("items").get("type"),
                 }
+                format = prop_schema.get("items").get("format")
+                if format:
+                    simple_schema["format"] = format
+                return simple_schema
             else:
-                return {
+                simple_schema = {
                     "data_type": prop_type,
                     "pattern": prop_schema.get("pattern"),
                     "max": prop_schema.get("maximum", 100),
                     "min": prop_schema.get("minimum", 0),
                 }
+                format = prop_schema.get("format")
+                if format:
+                    simple_schema["format"] = format
+                return simple_schema
 
         elif prop_schema.get("oneOf") or prop_schema.get("anyOf"):
             one_of = prop_schema.get("oneOf") or prop_schema.get("anyOf")
@@ -263,7 +273,11 @@ class Node(object):
                 data_type = one.get("type")
                 if not data_type:
                     continue
-                return {"data_type": data_type}
+                simple_schema = {"data_type": data_type}
+                format = one.get("format")
+                if format:
+                    simple_schema["format"] = format
+                return simple_schema
 
         elif prop_schema.get("enum"):
             if is_mixed_type(prop_schema.get("enum")):

--- a/datasimulator/submit_data_utils.py
+++ b/datasimulator/submit_data_utils.py
@@ -115,7 +115,7 @@ def submit_test_data(host, project, dir, access_token_file, max_chunk_size=1):
 
                 elif response.status_code != 200:
                     logger.error(
-                        "\n\n==============================={}=================================".format(
+                        "\n\n=============================== {} =================================".format(
                             fname
                         )
                     )


### PR DESCRIPTION
Jira Ticket: [PXP-9192](https://ctds-planx.atlassian.net/browse/PXP-9192)

after this update https://github.com/uc-cdis/sheepdog/pull/363, with simulated data `core_metadata_collection.date = b74eb3a5e6` and errors in integration tests:
```
"message":"'b74eb3a5e6' is not valid under any of the given schemas:
'b74eb3a5e6' is not a 'date-time' and 'b74eb3a5e6' is not of type 'null'",
"type":"INVALID_VALUE"}],
"id":null,"type":"core_metadata_collection"
```

### New Features
- Handle generating strings in `date-time` format
