### PR TITLE
Fix 'NoneType' object has no attribute 'required_links'

### DIFF
--- a/datasimulator/graph.py
+++ b/datasimulator/graph.py
@@ -216,10 +216,12 @@ class Graph(object):
 
         while index < len(submission_order):
             cur_node = submission_order[index]
+            index += 1
+            if not cur_node:
+                continue
             for linked_node_dict in cur_node.required_links:
                 if linked_node_dict["node"] not in submission_order:
                     submission_order.append(linked_node_dict["node"])
-            index += 1
         submission_order.reverse()
 
         return submission_order


### PR DESCRIPTION
```
[2022-02-10 18:41:27,966][data-simulator][   INFO] Generating data submission order...
Traceback (most recent call last):
  File "/usr/local/bin/data-simulator", line 5, in <module>
    main()
  File "/data-simulator/datasimulator/main.py", line 154, in main
    submission_order = graph.generate_submission_order_path_to_node(node)
  File "/data-simulator/datasimulator/graph.py", line 219, in generate_submission_order_path_to_node
    for linked_node_dict in cur_node.required_links:
AttributeError: 'NoneType' object has no attribute 'required_links'
```

### Bug Fixes
- Ignore empty nodes in `generate_submission_order_path_to_node` function
