### PR TITLE
PXP-10945 PXP-10952 Fix `array.items.oneOf.enum` + avoid null values

### DIFF
--- a/datasimulator/generator.py
+++ b/datasimulator/generator.py
@@ -85,7 +85,9 @@ def generate_array_data_type(
     elif item_type in {"float", "number"}:
         return [generate_number() for _ in range(n_items)]
     elif item_type == "enum":
-        return [random.choice(item_predefined_values)]
+        return random.sample(
+            item_predefined_values, min(n_items, len(item_predefined_values))
+        )
     else:
         raise UserError("Array item type '{}' is not supported".format(item_type))
 

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -163,7 +163,7 @@ def _simulate_data_from_simple_schema(simple_schema):
     elif simple_schema["data_type"] == "array":
         return generate_array_data_type(
             item_type=simple_schema.get("item_type"),
-            n_items=1,
+            n_items=random.randint(1, 3),
             item_predefined_values=simple_schema.get("item_enum_data", []),
             pattern=simple_schema.get("pattern", None),
             format=simple_schema.get("format"),

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -126,8 +126,14 @@ def construct_simple_property_schema(node_name, prop, prop_schema):
             return simple_schema
 
     elif prop_schema.get("oneOf") or prop_schema.get("anyOf"):
+        # pick one allowed type at random
         one_of = prop_schema.get("oneOf") or prop_schema.get("anyOf")
+        if len(one_of) > 1:
+            # avoid picking type=null to avoid this sheepdog bug: PXP-10952
+            # TODO remove this in a while when everyone uses the fixed sheepdog...
+            one_of = [e for e in one_of if e.get("type") != "null"]
         one = random.choice(one_of)
+
         if Node._is_link_property(one):
             return {"data_type": "link_type"}
         return construct_simple_property_schema(node_name, prop, one)

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -81,9 +81,23 @@ def construct_simple_property_schema(node_name, prop, prop_schema):
                     "oneOf"
                 ) or prop_schema.get("items", {}).get("anyOf")
                 if oneOfSchemas:
-                    return construct_simple_property_schema(
+                    sub_schema = construct_simple_property_schema(
                         node_name, prop, {"oneOf": oneOfSchemas}
                     )
+                    if sub_schema.get("data_type") == "enum" and sub_schema.get(
+                        "values"
+                    ):
+                        return {
+                            "data_type": "array",
+                            "item_type": "enum",
+                            "item_enum_data": sub_schema["values"],
+                        }
+                    else:
+                        raise DictionaryError(
+                            "Error: Data simulator does not know yet how to handle schema '{}' for prop '{}'. Debug: sub_schema={}".format(
+                                prop_schema, prop, sub_schema
+                            )
+                        )
                 else:
                     raise DictionaryError(
                         "Error: {} has no item datatype. Detail {}".format(

--- a/datasimulator/node.py
+++ b/datasimulator/node.py
@@ -130,7 +130,7 @@ def construct_simple_property_schema(node_name, prop, prop_schema):
         one_of = prop_schema.get("oneOf") or prop_schema.get("anyOf")
         if len(one_of) > 1:
             # avoid picking type=null to avoid this sheepdog bug: PXP-10952
-            # TODO remove this in a while when everyone uses the fixed sheepdog...
+            # TODO remove this in a while when everyone uses the fixed sheepdog 2023.07
             one_of = [e for e in one_of if e.get("type") != "null"]
         one = random.choice(one_of)
 


### PR DESCRIPTION
Jira Ticket: [PXP-10945](https://ctds-planx.atlassian.net/browse/PXP-10945)
and workaround for [PXP-10952](https://ctds-planx.atlassian.net/browse/PXP-10952)

### New Features


### Breaking Changes


### Bug Fixes
- Fix data generated for `array.items.oneOf.enum`: generate an array, not a single value

### Improvements
- Generate arrays with 1 to 3 values instead of always just 1
- Temporarily avoid generating null values for `oneOf` definitions that allow other types of values

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[PXP-10945]: https://ctds-planx.atlassian.net/browse/PXP-10945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXP-10952]: https://ctds-planx.atlassian.net/browse/PXP-10952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ