### PR TITLE
Always include 'core_metadata_collection' in 'DataImportOrderPath'

### DIFF
--- a/datasimulator/graph.py
+++ b/datasimulator/graph.py
@@ -200,7 +200,7 @@ class Graph(object):
                     )
                 )
 
-    def generate_submission_order_path_to_node(self, node):
+    def generate_submission_order_path_to_node(self, node, cmc_node=None):
         """
         Generate submission order so that the current node can be submitted
 
@@ -212,6 +212,8 @@ class Graph(object):
 
         """
         submission_order = [node]
+        if cmc_node:
+            submission_order.append(cmc_node)
         index = 0
 
         while index < len(submission_order):

--- a/datasimulator/main.py
+++ b/datasimulator/main.py
@@ -151,7 +151,14 @@ def main():
         logger.info("Generating data submission order...")
         if args.node_name:
             node = graph.get_node_with_name(args.node_name)
-            submission_order = graph.generate_submission_order_path_to_node(node)
+            cmc_node = graph.get_node_with_name("core_metadata_collection")
+            if not node:
+                raise Exception(
+                    f"Argument 'node_name' is '{args.node_name}' but this node does not exist"
+                )
+            submission_order = graph.generate_submission_order_path_to_node(
+                node, cmc_node
+            )
         else:
             submission_order = graph.generate_submission_order()
 


### PR DESCRIPTION
Fix error when the CI tries to access a core_metadata_collection record [here](https://github.com/uc-cdis/gen3-qa/blob/3789cb033cbf6544d180faf54447aae396abd4eb/utils/nodes.js#L304) but there isn't one because `DataImportOrderPath.txt` is read [here](https://github.com/uc-cdis/gen3-qa/blob/3789cb033cbf6544d180faf54447aae396abd4eb/utils/nodes.js#L74) and does not include this node

### Improvements
- Always include 'core_metadata_collection' in 'DataImportOrderPath'
