### PR TITLE
(PPS-710): use new release of gen3datamodel

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -330,8 +330,8 @@ strict-rfc3339 = "==0.7"
 [package.source]
 type = "git"
 url = "https://github.com/uc-cdis/gen3datamodel"
-reference = "chore/update-branches"
-resolved_reference = "b31628d2b13d0dd1a4269f8ef523726df72031c8"
+reference = "3.2.1"
+resolved_reference = "97d67c7bd2539f9d90ea0ccb899185ebe2ecc24c"
 
 [[package]]
 name = "gen3dictionary"
@@ -892,4 +892,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "e1204568b9ada71058fd1e26963c087fa73aedf09407b778ffbda5f53e707e6e"
+content-hash = "46f6becbde49e3d4884ba14c2b32e0a48ddcf005df94a655bf13a818a2084bf3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ data-simulator = 'datasimulator.main:main'
 [tool.poetry.dependencies]
 python = ">=3.9,<4"
 cdislogging = "*"
-gen3datamodel = {git = "https://github.com/uc-cdis/gen3datamodel", branch = "chore/update-branches"}
+gen3datamodel = {git = "https://github.com/uc-cdis/gen3datamodel", rev = "3.2.1"}
 gen3dictionary = "*"
 pyyaml = "<7"
 rstr = ">=3,<4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data-simulator"
-version = "1.6.3"
+version = "1.6.4"
 description = "Gen3 Data Simulator"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Relates to [PXP-11243](https://ctds-planx.atlassian.net/browse/PXP-11243) and [PPS-710](https://ctds-planx.atlassian.net/browse/PPS-710) 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
* Bump gen3datamodel to 3.2.1

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[PXP-11243]: https://ctds-planx.atlassian.net/browse/PXP-11243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PPS-710]: https://ctds-planx.atlassian.net/browse/PPS-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ